### PR TITLE
Added logErrors prop. Fixed usage example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import MyWidget from './MyWidget'
 import SentryErrorBoundary from 'react-sentry-error-boundary'
 import React from 'react'
 
-const App = () => {
+const App = () =>
   <SentryErrorBoundary
     dsn="https://<key>@sentry.io/<project>"
     errorNode={
@@ -32,7 +32,6 @@ const App = () => {
   >
     <MyWidget />
   </SentryErrorBoundary>
-}
 
 export default App
 ```
@@ -59,6 +58,11 @@ A callback function to execute on error.
 #### errorNode
 ```
 Required. A node to render on error.
+```
+
+#### logErrors
+```
+Defaults to true. Error logging can be disabled when set to false.
 ```
 
 #### userContext

--- a/src/ReactSentryErrorBoundary.js
+++ b/src/ReactSentryErrorBoundary.js
@@ -9,11 +9,13 @@ export default class ReactSentryErrorBoundary extends React.Component {
     dsn: PropTypes.string.isRequired,
     errorCallback: PropTypes.func,
     errorNode: PropTypes.node.isRequired,
+    logErrors: PropTypes.bool,
     userContext: PropTypes.object
   }
 
   static defaultProps = {
-    config: {}
+    config: {},
+    logErrors: true
   }
 
   constructor (props) {
@@ -29,7 +31,8 @@ export default class ReactSentryErrorBoundary extends React.Component {
       hasError: true
     })
 
-    this.logError(error)
+    
+    if (this.props.logErrors) this.logError(error)
 
     if (this.props.errorCallback) this.props.errorCallback()
   }


### PR DESCRIPTION
It would be super cool if the developer could test the ErrorBoundary usage without logging errors.